### PR TITLE
Adds KD-Tree Data Structure

### DIFF
--- a/include/DataStructure.h
+++ b/include/DataStructure.h
@@ -1,0 +1,24 @@
+// include/DataStructure.h
+#ifndef DATA_STRUCTURE_H
+#define DATA_STRUCTURE_H
+
+#include "CollisionEvent.h"
+#include <vector>
+
+/**
+ * @class DataStructure
+ * @brief Abstract base class (ABC) for data structures in the project (KD-Tree and Grid-Based Bucketing).
+ *
+ * Defines an interface for insertion, range queries, and extremum queries,
+ * enabling polymorphic use of k-d tree and grid-based bucketing, allowing
+ * for further performance insights.
+ */
+class DataStructure {
+public:
+    virtual void insert(const CollisionEvent& event) = 0;
+    virtual std::vector<CollisionEvent> range_query(float minRestEnergy, float maxRestEnergy) = 0;
+    virtual CollisionEvent find_max_efficiency() = 0;
+    virtual ~DataStructure() = default;
+};
+
+#endif // DATA_STRUCTURE_H

--- a/include/KDTree.h
+++ b/include/KDTree.h
@@ -1,0 +1,43 @@
+#ifndef KD_TREE_H
+#define KD_TREE_H
+
+#include "DataStructure.h"
+#include <memory>
+#include <vector>
+#include <algorithm>
+
+/**
+ * @class KDTree
+ * @brief k-d tree for efficient multi-dimensional range queries.
+ *
+ * Partitions data along kinetic and rest energy dimensions. Useful for
+ * querying events in specific energy ranges, e.g., to study resonance production.
+ *
+ * Background: Efficient range queries help identify events with specific rest-mass
+ * outputs, potentially linked to heavy particles like top quarks.
+ */
+struct Node {
+    int dimension;  ///< 0: kineticEnergyIn, 1: restEnergyOut.
+    float splitValue;  ///< Splitting threshold.
+    std::vector<CollisionEvent> events;  ///< Leaf bucket.
+    std::unique_ptr<Node> left, right;  ///< Child nodes.
+};
+
+class KDTree : public DataStructure {
+public:
+    KDTree();
+    void buildBalanced(std::vector<CollisionEvent>& events);
+    void insert(const CollisionEvent& event) override;
+    std::vector<CollisionEvent> range_query(float minRestEnergy, float maxRestEnergy) override;
+    CollisionEvent find_max_efficiency() override;
+private:
+    std::unique_ptr<Node> root;
+    const size_t bucketSize = 10;  ///< Max events per leaf.
+
+    std::unique_ptr<Node> buildRecursive(std::vector<CollisionEvent>& events, int depth);
+    void rangeQueryRecursive(const Node* node, float minRestEnergy, float maxRestEnergy,
+                             std::vector<CollisionEvent>& result);
+    CollisionEvent findMaxEfficiencyRecursive(const Node* node);
+};
+
+#endif // KD_TREE_H

--- a/src/KDTree.cpp
+++ b/src/KDTree.cpp
@@ -1,0 +1,86 @@
+#include "KDTree.h"
+#include <algorithm>
+#include <stdexcept>
+
+KDTree::KDTree() : root(nullptr) {}
+
+void KDTree::buildBalanced(std::vector<CollisionEvent>& events) {
+    // Sort events by restEnergyOut since kineticEnergyIn is constant
+    std::sort(events.begin(), events.end(), [](const CollisionEvent& a, const CollisionEvent& b) {
+        return a.restEnergyOut < b.restEnergyOut;
+    });
+    root = buildRecursive(events, 0);
+}
+
+std::unique_ptr<Node> KDTree::buildRecursive(std::vector<CollisionEvent>& events, int depth) {
+    if (events.empty()) return nullptr;
+    if (events.size() <= bucketSize) {
+        auto node = std::make_unique<Node>();
+        node->events = std::move(events);
+        return node;
+    }
+
+    int dim = 1; // Always split on restEnergyOut since kineticEnergyIn is constant
+    size_t median = events.size() / 2;
+    std::nth_element(events.begin(), events.begin() + median, events.end(),
+                     [](const CollisionEvent& a, const CollisionEvent& b) {
+                         return a.restEnergyOut < b.restEnergyOut;
+                     });
+
+    auto node = std::make_unique<Node>();
+    node->dimension = dim;
+    node->splitValue = events[median].restEnergyOut;
+
+    std::vector<CollisionEvent> leftEvents(events.begin(), events.begin() + median);
+    std::vector<CollisionEvent> rightEvents(events.begin() + median + 1, events.end());
+
+    node->left = buildRecursive(leftEvents, depth + 1);
+    node->right = buildRecursive(rightEvents, depth + 1);
+
+    return node;
+}
+
+void KDTree::insert(const CollisionEvent& event) {
+    // Kept for compatibility, but not used with buildBalanced
+    if (!root) {
+        root = std::make_unique<Node>();
+        root->events.push_back(event);
+    }
+}
+
+std::vector<CollisionEvent> KDTree::range_query(float minRestEnergy, float maxRestEnergy) {
+    std::vector<CollisionEvent> result;
+    rangeQueryRecursive(root.get(), minRestEnergy, maxRestEnergy, result);
+    return result;
+}
+
+void KDTree::rangeQueryRecursive(const Node* node, float minRestEnergy, float maxRestEnergy,
+                                 std::vector<CollisionEvent>& result) {
+    if (!node) return;
+    if (node->left || node->right) {
+        if (node->splitValue >= minRestEnergy)
+            rangeQueryRecursive(node->left.get(), minRestEnergy, maxRestEnergy, result);
+        if (node->splitValue <= maxRestEnergy)
+            rangeQueryRecursive(node->right.get(), minRestEnergy, maxRestEnergy, result);
+    } else {
+        for (const auto& e : node->events) {
+            if (e.restEnergyOut >= minRestEnergy && e.restEnergyOut <= maxRestEnergy)
+                result.push_back(e);
+        }
+    }
+}
+
+CollisionEvent KDTree::find_max_efficiency() {
+    return findMaxEfficiencyRecursive(root.get());
+}
+
+CollisionEvent KDTree::findMaxEfficiencyRecursive(const Node* node) {
+    if (!node) throw std::runtime_error("Empty tree");
+    if (!node->left && !node->right) {
+        return *std::max_element(node->events.begin(), node->events.end(),
+                                 [](const auto& a, const auto& b) { return a.efficiency < b.efficiency; });
+    }
+    CollisionEvent leftMax = findMaxEfficiencyRecursive(node->left.get());
+    CollisionEvent rightMax = findMaxEfficiencyRecursive(node->right.get());
+    return (leftMax.efficiency > rightMax.efficiency) ? leftMax : rightMax;
+}


### PR DESCRIPTION
Adds data structure to define an interface for insertion, range-queries, and extremum queries, enabling polymorphic use of k-d tree and grid-based bucketing. Also implements k-d tree for efficient multi-dimensional range queries. Partitions data along kinetic and rest energy dimensions. Useful for querying events in specific energy ranges, e.g., to study resonance production. Efficient range queries help identify events with specific rest-mass outputs, potentially linked to heavy particles like top quarks.